### PR TITLE
Changed regex to ignore parameters specified in requirements.txt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Fails if a requirement does not specify the version
   language: pygrep
   files: requirements.*\.txt$
-  entry: ^(?!\s*$)(?!#)(?!.+(?:={2,3}|!=|~=|>=?|<=?)[\S]+).*
+  entry: ^(?!\s*$)(?!#)(?!--)(?!.+(?:={2,3}|!=|~=|>=?|<=?)[\S]+).*


### PR DESCRIPTION
This pull request includes a minor update to the `.pre-commit-hooks.yaml` file. The change modifies the `entry` regex pattern for a pre-commit hook to exclude lines starting with double dashes (`--`), ensuring they are not flagged as invalid.

* [`.pre-commit-hooks.yaml`](diffhunk://#diff-cb921d5df435fe404b4daf451cf783709ccebe9c346038af6036644e7386c13dL6-R6): Updated the `entry` regex to add a condition that skips lines starting with `--` in the requirements file validation.